### PR TITLE
changed FindBindings to use Regex

### DIFF
--- a/src/Protractor/ClientSideScripts.cs
+++ b/src/Protractor/ClientSideScripts.cs
@@ -89,10 +89,11 @@ var using = arguments[0] || document;
 var binding = arguments[1];
 var bindings = using.getElementsByClassName('ng-binding');
 var matches = [];
+var matcher = new RegExp(binding);
 for (var i = 0; i < bindings.length; ++i) {
     var bindingName = angular.element(bindings[i]).data().$binding[0].exp ||
         angular.element(bindings[i]).data().$binding;
-    if (bindingName.indexOf(binding) != -1) {
+    if (matcher.test(bindingName)) {
         matches.push(bindings[i]);
     }
 }


### PR DESCRIPTION
With Angular 1.3 trying to find a binding in the following format seemed to break:

```
<span>{{ myBinding }}</span>
```

The data looks like this:
    angular.element(bindings[i]).data().$binding = [ " myBinding " ];

By switching to a RegExp, it basically does the indexOf test that was done before, but it seems to process on arrays as well (which looks to match the behavior in the main protractor repo).
