### PR TITLE
Add postfixes to FindAllRepeaterRows locator

### DIFF
--- a/src/Protractor/ClientSideScripts.cs
+++ b/src/Protractor/ClientSideScripts.cs
@@ -151,13 +151,16 @@ var using = arguments[0] || document;
 var repeater = arguments[1];
 var rows = [];
 var prefixes = ['ng-', 'ng_', 'data-ng-', 'x-ng-', 'ng\\:'];
+var postfixes = ['', '-start'];
 for (var p = 0; p < prefixes.length; ++p) {
-    var attr = prefixes[p] + 'repeat';
-    var repeatElems = using.querySelectorAll('[' + attr + ']');
-    attr = attr.replace(/\\/g, '');
-    for (var i = 0; i < repeatElems.length; ++i) {
-        if (repeatElems[i].getAttribute(attr).indexOf(repeater) != -1) {
-            rows.push(repeatElems[i]);
+    for (var po = 0; po < postfixes.length; ++po) {
+        var attr = prefixes[p] + 'repeat' + postfixes[po];
+        var repeatElems = using.querySelectorAll('[' + attr + ']');
+        attr = attr.replace(/\\/g, '');
+        for (var i = 0; i < repeatElems.length; ++i) {
+            if (repeatElems[i].getAttribute(attr).indexOf(repeater) != -1) {
+                rows.push(repeatElems[i]);
+            }
         }
     }
 }


### PR DESCRIPTION
Adding a postfix check to repeater locator.  This will find elements without postfixes and elements with a -start postfix.

I have not been able to determine any real impact on performance at least in my testing.  I imagine with the addition of more postfixes this might have the tendency to slow down a little.

The purpose of this addition is to tweak the FindAllRepeaterRows client side script so that it can find repeater elements that use ng-repeat-start and ng-repeat-end.