### PR TITLE
Updated JavaScriptBy class to be public

### DIFF
--- a/src/Protractor/JavaScriptBy.cs
+++ b/src/Protractor/JavaScriptBy.cs
@@ -7,7 +7,7 @@ using OpenQA.Selenium.Internal;
 
 namespace Protractor
 {
-    internal class JavaScriptBy : By
+    public class JavaScriptBy : By
     {
         private string script;
         private object[] args;


### PR DESCRIPTION
Allows people to be able to extend finding of elements however they wish and still be able to reuse the JavaScriptBy class to find element/elements without recreating that class