### PR TITLE
Added ability to use NgBy methods as CustomeTypeFilters in Selenium FindsBy for PageObjects

### DIFF
--- a/src/Protractor/JavaScriptBy.cs
+++ b/src/Protractor/JavaScriptBy.cs
@@ -7,37 +7,58 @@ using OpenQA.Selenium.Internal;
 
 namespace Protractor
 {
-    internal class JavaScriptBy : By
+    /// <summary>
+    /// Internal implementation of the By Selenium class, supporting custom JavaScript selection for angular components.
+    /// </summary>
+    public class JavaScriptBy : By
     {
-        private string script;
-        private object[] args;
+        private readonly string _script;
+        private readonly object[] _args;
 
+        /// <summary>
+        /// javaScriptBy ctor.
+        /// </summary>
+        /// <param name="script"></param>
+        /// <param name="args"></param>
         public JavaScriptBy(string script, params object[] args)
         {
-            this.script = script;
-            this.args = args;
+            this._script = script;
+            this._args = args;
         }
 
+        /// <summary>
+        /// RootElement.
+        /// </summary>
         public IWebElement RootElement { get; set; }
 
+        /// <summary>
+        /// FindElement Implementation.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
         public override IWebElement FindElement(ISearchContext context)
         {
             ReadOnlyCollection<IWebElement> elements = this.FindElements(context);
             return elements.Count > 0 ? elements[0] : null;
         }
 
+        /// <summary>
+        /// FindElements Implementation.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
         public override ReadOnlyCollection<IWebElement> FindElements(ISearchContext context)
         {
             // Create script arguments
-            object[] scriptArgs = new object[this.args.Length + 1];
+            object[] scriptArgs = new object[this._args.Length + 1];
             scriptArgs[0] = this.RootElement;
-            Array.Copy(this.args, 0, scriptArgs, 1, this.args.Length);
+            Array.Copy(this._args, 0, scriptArgs, 1, this._args.Length);
 
             // Get JS executor
-            IJavaScriptExecutor jsExecutor = context as IJavaScriptExecutor;
+            var jsExecutor = context as IJavaScriptExecutor;
             if (jsExecutor == null)
             {
-                IWrapsDriver wrapsDriver = context as IWrapsDriver;
+                var wrapsDriver = context as IWrapsDriver;
                 if (wrapsDriver != null)
                 {
                     jsExecutor = wrapsDriver.WrappedDriver as IJavaScriptExecutor;
@@ -48,7 +69,7 @@ namespace Protractor
                 throw new NotSupportedException("Could not get an IJavaScriptExecutor instance from the context.");
             }
 
-            ReadOnlyCollection<IWebElement> elements = jsExecutor.ExecuteScript(this.script, scriptArgs) as ReadOnlyCollection<IWebElement>;
+            var elements = jsExecutor.ExecuteScript(_script, scriptArgs) as ReadOnlyCollection<IWebElement>;
             if (elements == null)
             {
                 elements = new ReadOnlyCollection<IWebElement>(new List<IWebElement>(0));

--- a/src/Protractor/NgByBinding.cs
+++ b/src/Protractor/NgByBinding.cs
@@ -1,0 +1,17 @@
+﻿namespace Protractor
+{
+    /// <summary>
+    /// Wrapper around the NgBy.Binding() static method to provide typed By selector for FindsByAttribute usage.
+    /// </summary>
+    public class NgByBinding : JavaScriptBy
+    {
+        /// <summary>
+        /// NgByBinding ctor.
+        /// </summary>
+        /// <param name="binding"></param>
+        public NgByBinding(string binding)
+            : base(ClientSideScripts.FindBindings, binding)
+        {
+        }
+    }
+}

--- a/src/Protractor/NgByModel.cs
+++ b/src/Protractor/NgByModel.cs
@@ -1,0 +1,17 @@
+﻿namespace Protractor
+{
+    /// <summary>
+    /// Wrapper around the NgBy.Model() static method to provide typed By selector for FindsByAttribute usage.
+    /// </summary>
+    public class NgByModel : JavaScriptBy
+    {
+        /// <summary>
+        /// NgByRepeater ctor.
+        /// </summary>
+        /// <param name="model"></param>
+        public NgByModel(string model)
+            : base(ClientSideScripts.FindModel, model)
+        {
+        }
+    }
+}

--- a/src/Protractor/NgByRepeater.cs
+++ b/src/Protractor/NgByRepeater.cs
@@ -1,0 +1,17 @@
+﻿namespace Protractor
+{
+    /// <summary>
+    /// Wrapper around the NgBy.Repeater() static method to provide typed By selector for FindsByAttribute usage.
+    /// </summary>
+    public class NgByRepeater : JavaScriptBy
+    {
+        /// <summary>
+        /// NgByRepeater ctor.
+        /// </summary>
+        /// <param name="repeat"></param>
+        public NgByRepeater(string repeat)
+            : base(ClientSideScripts.FindAllRepeaterRows, repeat)
+        {
+        }
+    }
+}

--- a/src/Protractor/NgBySelectedOption.cs
+++ b/src/Protractor/NgBySelectedOption.cs
@@ -1,0 +1,17 @@
+﻿namespace Protractor
+{
+    /// <summary>
+    /// Wrapper around the NgBy.SelectedOption() static method to provide typed By selector for FindsByAttribute usage.
+    /// </summary>
+    public class NgBySelectedOption : JavaScriptBy
+    {
+        /// <summary>
+        /// NgBySelectedOption ctor.
+        /// </summary>
+        /// <param name="model"></param>
+        public NgBySelectedOption(string model)
+            : base(ClientSideScripts.FindSelectedOptions, model)
+        {
+        }
+    }
+}

--- a/src/Protractor/NgWebDriver.cs
+++ b/src/Protractor/NgWebDriver.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 using OpenQA.Selenium;
@@ -15,10 +14,10 @@ namespace Protractor
     {
         private const string AngularDeferBootstrap = "NG_DEFER_BOOTSTRAP!";
 
-        private IWebDriver driver;
-        private IJavaScriptExecutor jsExecutor;
-        private string rootElement;
-        private NgModule[] mockModules;
+        private readonly IWebDriver driver;
+        private readonly IJavaScriptExecutor jsExecutor;
+        private readonly string rootElement;
+        private readonly NgModule[] mockModules;
 
         /// <summary>
         /// Creates a new instance of <see cref="NgWebDriver"/> by wrapping a <see cref="IWebDriver"/> instance.
@@ -178,6 +177,7 @@ namespace Protractor
                 }
                 else
                 {
+                    //TODO MGA : this may not be a good approach, protractor could still be used interchangeably with pages with or without angular, should not break !
                     throw new InvalidOperationException(
                         String.Format("Angular could not be found on the page '{0}'", value));
                 }
@@ -291,7 +291,11 @@ namespace Protractor
 
         #endregion
 
-        internal void WaitForAngular()
+        /// <summary>
+        /// Waits for angular to finish any ongoing $http, $timeouts, digest cycles etc.
+        /// This is used before any action on this driver, except if IgnoreSynchonization flag is set to true.
+        /// </summary>
+        public void WaitForAngular()
         {
             if (!this.IgnoreSynchronization)
             {

--- a/src/Protractor/NgWebElement.cs
+++ b/src/Protractor/NgWebElement.cs
@@ -12,8 +12,8 @@ namespace Protractor
     /// </summary>
     public class NgWebElement : IWebElement, IWrapsElement
     {
-        private NgWebDriver ngDriver;
-        private IWebElement element;
+        private readonly NgWebDriver ngDriver;
+        private readonly IWebElement element;
 
         /// <summary>
         /// Creates a new instance of <see cref="NgWebElement"/> by wrapping a <see cref="IWebElement"/> instance.

--- a/src/Protractor/Protractor-NET40.csproj
+++ b/src/Protractor/Protractor-NET40.csproj
@@ -38,9 +38,10 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
-    <Reference Include="WebDriver, Version=2.47.0.0, Culture=neutral, processorArchitecture=MSIL">
-        <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Selenium.WebDriver.2.47.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=2.48.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Selenium.WebDriver.2.48.2\lib\net40\WebDriver.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Protractor/Protractor-NET40.csproj
+++ b/src/Protractor/Protractor-NET40.csproj
@@ -38,14 +38,18 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
-    <Reference Include="WebDriver, Version=2.46.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Selenium.WebDriver.2.46.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=2.47.0.0, Culture=neutral, processorArchitecture=MSIL">
+        <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Selenium.WebDriver.2.47.0\lib\net40\WebDriver.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NgBySelectedOption.cs" />
+    <Compile Include="NgByRepeater.cs" />
+    <Compile Include="NgByBinding.cs" />
     <Compile Include="JavaScriptBy.cs" />
     <Compile Include="NgBy.cs" />
+    <Compile Include="NgByModel.cs" />
     <Compile Include="NgNavigation.cs" />
     <Compile Include="NgWebDriver.cs" />
     <Compile Include="ClientSideScripts.cs" />

--- a/src/Protractor/packages.config
+++ b/src/Protractor/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Selenium.WebDriver" version="2.46.0" targetFramework="net40" />
+  <package id="Selenium.WebDriver" version="2.47.0" targetFramework="net40" />
 </packages>

--- a/src/Protractor/packages.config
+++ b/src/Protractor/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Selenium.WebDriver" version="2.47.0" targetFramework="net40" />
+  <package id="Selenium.WebDriver" version="2.48.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This enables use cases of the form : 

[FindsBy(How = How.Custom, CustomFinderType = typeof(NgByRepeater), Using = "item in
collection")]
public IList<IWebElement> items { get; set; }

Side effect : JavaScriptBy needs to be public

Additional change : bounced Selenium.WebDriver to 2.47. (Can be rollbacked to be done separatly).