### PR TITLE
Fixed Issue that caused Safari to sometimes hang on page load

### DIFF
--- a/src/Protractor/NgWebDriver.cs
+++ b/src/Protractor/NgWebDriver.cs
@@ -148,13 +148,14 @@ namespace Protractor
                 // Reset URL
                 this.driver.Url = "about:blank";
 
-                // TODO: test Safari & Android
+                // TODO: test Android
                 IHasCapabilities hcDriver = this.driver as IHasCapabilities;
                 if (hcDriver != null &&
                     (hcDriver.Capabilities.BrowserName == "internet explorer" ||
-                     hcDriver.Capabilities.BrowserName == "phantomjs"))
+                     hcDriver.Capabilities.BrowserName == "phantomjs" ||
+                     hcDriver.Capabilities.BrowserName.ToLower() == "safari"))
                 {
-                    // Internet Explorer & PhantomJS
+                    // Internet Explorer, PhantomJS & Safari
                     this.jsExecutor.ExecuteScript("window.name += '" + AngularDeferBootstrap + "';");
                     this.driver.Url = value;
                 }


### PR DESCRIPTION
Safari was falling down the wrong page loading path, I added a check for
Safari and guide it down the path that IE and PhantomJS run down.  I
verified this change against Desktop Safari in SauceLabs and against the
iOS simulator

Closes #46