### PR TITLE
Add ability to switch between Angular and non-Angular pages

### DIFF
--- a/src/Protractor/AngularVersion.cs
+++ b/src/Protractor/AngularVersion.cs
@@ -1,0 +1,23 @@
+﻿namespace Protractor
+{
+    /// <summary>
+    /// Represents versions of Angular
+    /// </summary>
+    public enum AngularVersion
+    {
+        /// <summary>
+        /// No angular
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// AngularJS
+        /// </summary>
+        AngularJS,
+
+        /// <summary>
+        /// Angular 2
+        /// </summary>
+        Angular2
+    }
+}

--- a/src/Protractor/ClientSideScripts.cs
+++ b/src/Protractor/ClientSideScripts.cs
@@ -66,16 +66,20 @@ testabilities.forEach(function(testability) {
          */
         public const string TestForAngular = @"
 var callback = arguments[0];
-var check = function() {
+var check = function(isFirstCall) {
     if (window.getAllAngularTestabilities) {
         callback(2);
     } else if (window.angular && window.angular.resumeBootstrap) {
         callback(1);
     } else {
-        window.setTimeout(function() {check()}, 1000);
+        if (isFirstCall) {
+            window.setTimeout(function() {check(false)}, 1000);
+        } else {
+            callback(null);
+        }
     }
 };
-check();";
+check(true);";
 
         /**
          * Continue to bootstrap Angular. 

--- a/src/Protractor/Protractor-NET35.csproj
+++ b/src/Protractor/Protractor-NET35.csproj
@@ -43,6 +43,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AngularVersion.cs" />
     <Compile Include="JavaScriptBy.cs" />
     <Compile Include="Ng1BaseModule.cs" />
     <Compile Include="NgBy.cs" />

--- a/src/Protractor/Protractor-NET40.csproj
+++ b/src/Protractor/Protractor-NET40.csproj
@@ -44,6 +44,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AngularVersion.cs" />
     <Compile Include="JavaScriptBy.cs" />
     <Compile Include="NgBy.cs" />
     <Compile Include="NgByBinding.cs" />


### PR DESCRIPTION
With this change user can switch modes of NgWebDriver between AngularJS, Angular 2 and non Angular pages.

User can navigate to non Angular page (e.g. login page) then switch to Angular page with the same driver instance.